### PR TITLE
Remove matplotlib constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ scipy
 astropy
 fastavro
 astroquery
-matplotlib<=3.5.3
+matplotlib
 tqdm>=4.64.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ astropy
 fastavro
 astroquery
 matplotlib
+PyQt5
 tqdm>=4.64.0


### PR DESCRIPTION
Remove matplotlib version constraint as requested in issue #42 